### PR TITLE
Override `prism` styling to enforce the design specs for the code field

### DIFF
--- a/imports/admin/_form.scss
+++ b/imports/admin/_form.scss
@@ -361,6 +361,15 @@
   }
 }
 
+// Field code
+
+.field-code:not(pre)  {
+  > code[class*="language-"] {
+    @extend .input;
+    min-height: $size*10;
+  }
+}
+
 // Input icons
 
 .input-icon {


### PR DESCRIPTION
> They should default to a decent size (at least 5 - 10 rows). The background color is also off putting, can't it be the same as our other inputs?

Story: [#138405947](https://www.pivotaltracker.com/story/show/138405947)