### PR TITLE
Fix RTE styles

### DIFF
--- a/imports/admin/_b_blocks.scss
+++ b/imports/admin/_b_blocks.scss
@@ -324,6 +324,11 @@ $block-size: 50px;
 				}
 			}
 			.editor {
+				a span {
+					color: #29a0d1;
+					text-decoration: none;
+					transition: all, 0.4s;
+				}
 				font-size: 12px;
 			}
 			.button {

--- a/imports/admin/_b_blocks.scss
+++ b/imports/admin/_b_blocks.scss
@@ -312,6 +312,17 @@ $block-size: 50px;
 			.label {
 				display: none;
 			}
+			.toolbar {
+				[class*="Dropdown__root"] {
+					select {
+						height: 30px;
+						line-height: 22px;
+					}
+					span {
+						color: transparent;
+					}
+				}
+			}
 			.editor {
 				font-size: 12px;
 			}


### PR DESCRIPTION
This PR corrects the styles for the current rich text editor, concretely:

- the select value was showing two times
- the select height
- the hyperlinks within the editor

It may be approached or simplified in other way @Dime, I would appreciate to learn about it if is the case.

I approached this style stuff as well because there were some issues on the RTE taking into account JS context, as covered here: https://github.com/pathable/pathable-ui/pull/356