### PR TITLE
add styles for input and button within popover

### DIFF
--- a/imports/admin/_editor.scss
+++ b/imports/admin/_editor.scss
@@ -170,6 +170,27 @@
      list-style-position: inside;
      margin-left: 15px;
   }
+
+  .ant-popover-inner {
+    background: $slate-light2;
+    @include pie-clearfix;
+    input {
+      float: left !important; // FIXME
+      width: auto !important; // FIXME
+      height: 35px !important; // FIXME
+      line-height: 35px !important; // FIXME
+      margin-right: 5px !important; // FIXME
+    }
+    button {
+      @extend .button--success;
+      float: right !important; // FIXME
+      height: 35px !important; // FIXME
+      outline: none !important; // FIXME
+    }
+    .hide {
+      display: none !important; // FIXME
+    }
+  }
 }
 
 @media screen and (min-width: 1401px) {


### PR DESCRIPTION
@Dime I am gonna need when you come back to review this styles. I finally achieved to place the popup inside the editor element, instead of globally inside the `document.body`. So I have run into conflicts between styles and for advancing other work I just place them as important to override, which is not a really good solution. As you have better view about how you organized the styles, it would be good if you can review and fix this.

This is for the link control.