### PR TITLE
display the footer on desktop

### DIFF
--- a/imports/admin/_agenda_mobile.scss
+++ b/imports/admin/_agenda_mobile.scss
@@ -153,8 +153,4 @@
   }
 }
 
-.preview-desktop {
-  .group-footer {
-    display: none;
-  }
-}
+.preview-desktop {}

--- a/imports/admin/_agenda_mobile.scss
+++ b/imports/admin/_agenda_mobile.scss
@@ -153,4 +153,10 @@
   }
 }
 
-.preview-desktop {}
+.preview-desktop {
+  [class*="section-"].group-page-layout.page-meetings {
+    .group-footer {
+      display: none;
+    }
+  }
+}

--- a/imports/admin/_custom.scss
+++ b/imports/admin/_custom.scss
@@ -61,9 +61,9 @@
       height: 100%;
       overflow-y: auto !important;
     }
-  }
-  .group-footer {
-    display: none;
+    .group-footer {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
Story: [#150714634](https://www.pivotaltracker.com/story/show/150714634)

@Dime I have corrected the styles to only affect the mobile view and the meeting list page list (desktop and mobile) to hide the footer. 

Not sure the needs of showing the footer on system pages, but at least the footer is shown somewhere else.