### PR TITLE
Create styles for the free spot used for sort behavior on widgets

### DIFF
--- a/imports/admin/_b_blocks.scss
+++ b/imports/admin/_b_blocks.scss
@@ -356,12 +356,16 @@ $block-size: 50px;
 		// -moz-box-shadow: 3px 3px 0 0 rgba(204,204,204,1);
 		box-shadow: 2px 2px 0 0 rgba(#fff,0.2), 3px 3px 0 0 rgba($slate,0.2);
 		border-radius: 3px;
-		margin: $size/3 0;
 		&:first-of-type {
 			margin-top: 0;
 		}
 		@media screen and (max-width:500px) {
 			box-shadow: 0 2px 0 0 rgba(#fff,0.2), 0 3px 0 0 rgba($slate,0.2);
+		}
+	}
+	&.group.over {
+		& .b-block {
+			border: 1px solid blue;
 		}
 	}
 	&.group.opened {

--- a/imports/admin/_b_blocks.scss
+++ b/imports/admin/_b_blocks.scss
@@ -178,9 +178,19 @@ $block-size: 50px;
 	}
 }
 
+// Block free spot
+.b-block-free-spot {
+	width: 100%;
+	height: $size/4;
+	&.over {
+		height: auto;
+		background-color: blue;
+		color: white;
+	}
+}
+
 // Block row
 .b-block-row {
-	margin-bottom: $size/4;
 	@include pie-clearfix;
 	&:last-child {
 		margin-bottom: 0;

--- a/imports/admin/_b_blocks.scss
+++ b/imports/admin/_b_blocks.scss
@@ -202,11 +202,35 @@ $block-size: 50px;
 // Block free spot
 .b-block-free-spot {
 	width: 100%;
-	height: $size/4;
+	height: 6px;
+	position: relative;
+	transition: height 0.4s;
 	&.over {
-		height: auto;
-		background-color: blue;
-		color: white;
+		height: 30px;
+		&:before {
+			background: $blue;
+			content: '';
+			display: block;
+			height: 1px;
+			width: 100%;
+			z-index: 1;
+			@include center;
+		}
+		span {
+			background: $white;
+			border: 1px solid $blue;
+			color: $blue;
+			display: block;
+			font-size: 9px;
+			height: 15px;
+			letter-spacing: 1px;
+			line-height: 15px;
+			padding: 0 7px;
+			text-transform: uppercase;
+			z-index: 2;
+			@include border-radius(2px);
+			@include center;
+		}
 	}
 }
 
@@ -214,6 +238,7 @@ $block-size: 50px;
 .b-block-row {
 	@include pie-clearfix;
 	margin: $size/3 0;
+	position: relative;
 	&:last-child {
 		margin-bottom: 0;
 	}
@@ -376,18 +401,35 @@ $block-size: 50px;
 	&.group {
 		// -webkit-box-shadow: 3px 3px 0 0 rgba(204,204,204,1);
 		// -moz-box-shadow: 3px 3px 0 0 rgba(204,204,204,1);
-		box-shadow: 2px 2px 0 0 rgba(#fff,0.2), 3px 3px 0 0 rgba($slate,0.2);
+		box-shadow: 2px 2px 0 0 rgba(#fff,0.2), 2px 2px 0 0 rgba($slate,0.2);
 		border-radius: 3px;
 		&:first-of-type {
 			margin-top: 0;
 		}
 		@media screen and (max-width:500px) {
-			box-shadow: 0 2px 0 0 rgba(#fff,0.2), 0 3px 0 0 rgba($slate,0.2);
+			box-shadow: 0 2px 0 0 rgba(#fff,0.2), 0 2px 0 0 rgba($slate,0.2);
 		}
 	}
 	&.group.over {
-		& .b-block {
-			border: 1px solid blue;
+		& .b-block-content {
+			box-shadow: 0 0 0 1px $blue inset;
+			@include pie-clearfix;
+			&:after {
+				background: $white;
+				border: 1px solid $blue;
+				color: $blue;
+				content: 'drop here';
+				display: block;
+				font-size: 9px;
+				height: 15px;
+				letter-spacing: 1px;
+				line-height: 15px;
+				padding: 0 7px;
+				text-transform: uppercase;
+				z-index: 2;
+				@include border-radius(2px);
+				@include center;
+			}
 		}
 	}
 	&.group.opened {
@@ -453,10 +495,10 @@ $block-size: 50px;
 // Block item
 
 .b-block {
-	position: static;
+	position: relative;
 	width: 100%;
 	@include pie-clearfix;
-	@include transition(all .4s);
+	transition: all, .4s;
 	[class*="block-"]:not(.b-block-actions, .b-block-show) {
 		float: left;
 	}

--- a/imports/admin/_b_blocks.scss
+++ b/imports/admin/_b_blocks.scss
@@ -11,6 +11,10 @@ $block-size: 50px;
 	&.twothirds {
 		width: 66.666%;
 	}
+
+	& .b-block-free-spot ~ .b-block-row {
+		margin: 0;
+	}
 }
 
 // Block columns controls
@@ -192,6 +196,7 @@ $block-size: 50px;
 // Block row
 .b-block-row {
 	@include pie-clearfix;
+	margin: $size/3 0;
 	&:last-child {
 		margin-bottom: 0;
 	}


### PR DESCRIPTION
https://github.com/pathable/pathable-ui/pull/438

I have used a new markup element in order to detect when a widget is being over within and be able to change the markup and style state. You can see the actual behavior [here](https://www.pivotaltracker.com/file_attachments/84016549/download?inline=true). We should tweak it to look it better. 