### PR TITLE
Remove focus style from dayswitcher tab [#150969450]

### DIFF
--- a/imports/admin/_agenda_toolbar.scss
+++ b/imports/admin/_agenda_toolbar.scss
@@ -469,8 +469,10 @@
     line-height: 0.9;
     padding: 10px 0;
     @include box-sizing(border-box);
-    &:hover,
     &:focus {
+      color: $slate-light2;
+    }
+    &:hover {
       background: $slate;
       color: $orange;
     }


### PR DESCRIPTION
Removed focus styling from tab because its already applied with .active, and when you clicked a tab it stayed focused even if the active tab changed by scrolling down. Had to re-apply the color because of specificity issues with base.scss.